### PR TITLE
Fixed wrong URL validating.

### DIFF
--- a/src/PHPThumb/PHPThumb.php
+++ b/src/PHPThumb/PHPThumb.php
@@ -84,7 +84,7 @@ abstract class PHPThumb
      */
     protected function validateRequestedResource($filename)
     {
-        if(true === filter_var($filename, FILTER_VALIDATE_URL)) {
+        if(false !== filter_var($filename, FILTER_VALIDATE_URL)) {
             $this->remoteImage = true;
             return true;
         }


### PR DESCRIPTION
See the the definition of the return values of filter_var http://php.net/manual/de/function.filter-var.php

Now you can provide a ling to an image again.
