### PR TITLE
Don't replace with %20 when the filename isn't a URL

### DIFF
--- a/src/GdThumb.inc.php
+++ b/src/GdThumb.inc.php
@@ -1470,7 +1470,9 @@ class GdThumb extends ThumbBase
 		}
 		
 		// According to php.net, getimagesize does not accept spaces in filenme. 
-		$formatInfo = getimagesize(str_replace(' ','%20',$this->fileName));
+		$filename = $this->fileName;
+		if (preg_match('#^https?//"#', $this->fileName)) $filename = str_replace(' ','%20', $filename);
+		$formatInfo = getimagesize($filename);
 		
 		// non-image files will return false
 		if ($formatInfo === false)


### PR DESCRIPTION
This line was making local directories with a space in them get subbed with %20.  For instance, if your path to your image is "/i have a space/in my dir/file.jpg", it was becoming "/i have%20a%20space/in%20my%20dir/file.jpg" which doesn't resolve.
