### PR TITLE
allow for versions of symfony/filesystem greater than 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["image", "resize", "rotate"],
     "require": {
         "php": ">=5.3.0",
-        "symfony/filesystem": "2.2.*"
+        "symfony/filesystem": ">=2.2.0"
     },
     "homepage": "https://github.com/masterexploder/PHPThumb",
     "authors": [


### PR DESCRIPTION
This PR changes the version requirement for "symfony/filesystem" from `2.2.*` to `>=2.2.0`, allowing for wider support when already using symfony packages in your project.
My project is currently using version `2.8.x-dev` and the PHPThumb unit tests succeed.
